### PR TITLE
Change style of webpage to look a bit like emacs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
     <footer>
       <div class="row">
         <div class="large-12 columns">
-          <a href="https://github.com/emacs-berlin/emacs-berlin.org" target="_blank">Site source code is available on Github.</a>
+          <a href="https://github.com/emacs-berlin/emacs-berlin.org" target="_blank">Site source code is available on GitHub</a>
         </div>
       </div>
     </footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,13 +13,18 @@
 
     {{ content }}
 
-    <footer>
+    <footer class='buffer-footer'>
       <div class="row">
         <div class="large-12 columns">
           <a href="https://github.com/emacs-berlin/emacs-berlin.org" target="_blank">Site source code is available on GitHub</a>
         </div>
       </div>
     </footer>
+
+    <footer class='mode-line'>
+      U:--- {{page.path}}&lt;emacs-berlin.org&gt;&nbsp;&nbsp;&nbsp;Git:gh-pages&nbsp;&nbsp;(Markdown Jekyll)
+    </footer>
+    <footer class='minibuffer'></footer>
 
     <script src="js/vendor/jquery.js"></script>
     <script src="js/foundation.min.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,6 +28,7 @@
 
     <script src="js/vendor/jquery.js"></script>
     <script src="js/foundation.min.js"></script>
+    <script src="js/sillyness.js"></script>
     <script>
       $(document).foundation();
     </script>

--- a/css/screen.css
+++ b/css/screen.css
@@ -100,3 +100,10 @@ h3 {
   overflow: hidden;
   white-space: nowrap;
 }
+
+.text-cursor {
+  background: black;
+  width: 1em;
+  height: 1em;
+  display: none;
+}

--- a/css/screen.css
+++ b/css/screen.css
@@ -3,11 +3,18 @@ body {
   color: #404041;
   padding: 0;
   margin: 0;
-  font-family: 'Lato', Helvetica, Arial, sans-serif;
-  font-weight: 400;
-  font-size: 18px;
+  font-family: Courier New,monospace;
   line-height: 1.5;
   position: relative;
+}
+
+h1, h2, h3 {
+  font-family: 'Lato', Helvetica, Arial, sans-serif;
+}
+
+ul {
+  list-style-type: '- ';
+  padding-left: 1em;
 }
 
 a {
@@ -56,6 +63,40 @@ h3 {
   font-weight: 900;
 }
 
-footer {
-  padding-bottom: 3%;
+.buffer-footer {
+  padding-bottom: 4em;
+}
+
+.mode-line {
+  position: fixed;
+  bottom: 1.4em;
+  width: 100%;
+  font-family: Courier New,monospace;
+
+  border-bottom: 1px solid gray;
+
+  background: #aaba5c;
+
+  height: 1.4em;
+  line-height: 1em;
+  padding: 0.2em;
+  margin: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.minibuffer {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  font-family: Courier New,monospace;
+
+  background: #dee28f;
+
+  height: 1.4em;
+  line-height: 1em;
+  padding: 0.2em;
+  margin: 0;
+  overflow: hidden;
+  white-space: nowrap;
 }

--- a/index.md
+++ b/index.md
@@ -26,7 +26,8 @@ You can also chat with us on irc:
 [#emacs-berlin](irc://chat.freenode.net/emacs-berlin)
 
 Or on Twitter:
-[@emacsberlin](https://twitter.com/emacsberlin)
+[@emacsberlin](https://twitter.com/emacsberlin) <span class='text-cursor'>&nbsp;</span>
+
 
 
 </div>

--- a/index.md
+++ b/index.md
@@ -34,11 +34,8 @@ Or on Twitter:
 ### Upcoming
 
 * Wednesday 29 July 2015, 19:00
-* Wednesday 26 August 2015, 19:00
-* Wednesday 30 September 2015, 19:00
 
-<small>(if you see past dates here, we were too lame to update this
-page, pls check the [mailing list][mla])</small>
+(if you see a past date here, pls check the [mailing list][mla])
 
 ### Location
 
@@ -49,14 +46,13 @@ outside in the Biergarten of
 Oranienplatz 11-13
 Kreuzberg
 
-The location is also always announced on the [mailing list][mla], so
-keep an eye on there.
+### Archive
 
-### [Archive](/archive.html)
+[Archive of previous meetings](/archive.html)
 
 </div></div></section>
 
-<section id="end-fold"><div class="row"><div class="large-8 columns">
+<section id="end-fold"><div class="row"><div class="large-12 columns">
 
 ## Beginner's Guarantee
 

--- a/js/sillyness.js
+++ b/js/sillyness.js
@@ -1,0 +1,16 @@
+jQuery(function() {
+  var textCursor = jQuery('.text-cursor'),
+      minibuffer = jQuery('.minibuffer');
+
+  setInterval(function() {
+    textCursor.toggle();
+  }, 500);
+
+  jQuery('body').keypress(function(e) {
+    if (e.key.length == 1) {
+      minibuffer.text('Editing not possible here, use the real thing');
+    } else {
+      minibuffer.text('');
+    }
+  });
+});


### PR DESCRIPTION
I thought it would be fun to make our web page look a little bit like emacs itself, so as a first step, here is a fake mode-line. It doesn't do anything dynamic, besides showing the current filename (e.g. `index.md`). I find that sufficient for now, but of course the possibilities for extensions are endless. For example it would be nice to show `End of buffer` message in the minibuffer when scrolled to the bottom. But also very silly :smile:

Please don't merge yet - I would like deploy this together with at least one more change, that is to change the overall font to a monospace font as well, and I wanted to ask for your feedback before doing that. Any ideas, objections? We could still use the current, sans-serif non monospace font for the headlines, but for the body text I would find it nice to use the same font as in the new mode-line. Not sure what to do with the side column layout, maybe keep it for now, or maybe change it to a linear layout where everything is on top of each other?

Maybe add a blinking cursor as well?